### PR TITLE
 Add onQueryComplete callback 

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,5 +7,6 @@
 
 [options]
 suppress_comment=.*\\$FlowFixMe
+suppress_comment=.*\\$FlowIssue
 esproposal.class_instance_fields=enable
 esproposal.class_static_fields=enable

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ script:
   - node --version
   - yarn --version
   - yarn run test
+  - yarn run flow
 notifications:
   email: false
 cache:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ if (process.env.NODE_ENV === 'development') {
 
 > Note: We do not recommend running this module in production, that's why you should guard the `inspect` call with `process.env` check.
 
-### Listening for new queries
+### Options
+
+#### onQuery: Keep track of your queries
 
 To listen to new queries provide the `onQuery` callback:
 
@@ -38,6 +40,22 @@ inspect(r, {
 ```
 
 This callback gets called with a string that looks like the query you made. So, for example, if you were to run `r.db('main').table('users').get('max').run()` your `onQuery` callback would get passed `"r.db('main').table('users').get('max').run()"`.
+
+#### onQueryComplete: Get query performance information
+
+To listen to completed queries provide the `onQueryComplete` callback:
+
+```JS
+inspect(r, {
+  onQueryComplete: (query, time) => {
+    console.log(query, time);
+  }
+})
+```
+
+This callback gets the same string of the query that `onQuery` gets, but also gets the time it took for the query to complete. This can be very useful for performance optimizations.
+
+> Note: The time it takes for a query to complete is very dependent on the system you're running on. Take the generated times with a grain of salt and only compare them between each other, never between different machines or runs.
 
 ## License
 

--- a/flow-typed/npm/performance-now_vx.x.x.js
+++ b/flow-typed/npm/performance-now_vx.x.x.js
@@ -1,0 +1,6 @@
+// flow-typed signature: 355b54f7dcef920415dacc455d5bbe4a
+// flow-typed version: <<STUB>>/performance-now_v0.2.0/flow_v0.55.0
+
+declare module 'performance-now' {
+  declare module.exports: () => number;
+}

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "prebuild": "rimraf dist",
     "build": "babel src --out-dir dist --ignore '*.test.js'",
     "test": "jest src",
-    "prettier": "prettier --write --single-quote --trailing-comma es5 'src/**/*.js'",
+    "prettier": "prettier --write",
     "flow": "flow src"
   },
   "lint-staged": {
     "*.js": [
-      "prettier --write --single-quote --trailing-comma es5",
+      "prettier --write",
       "git add"
     ]
   },

--- a/src/error.js
+++ b/src/error.js
@@ -4,6 +4,7 @@ function RethinkDBInspectorError(message: string) {
   Error.captureStackTrace(this, RethinkDBInspectorError);
 }
 
+// $FlowIssue
 RethinkDBInspectorError.prototype = new Error();
 RethinkDBInspectorError.prototype.name = 'RethinkDBInspectorError';
 

--- a/src/get-query-string.js
+++ b/src/get-query-string.js
@@ -1,0 +1,10 @@
+// @flow
+const { ReqlRuntimeError } = require('rethinkdbdash/lib/error');
+
+// Use ReqlRuntimeError constructor to get the query as a nicely formatted string
+function getQueryString() {
+  const error = new ReqlRuntimeError('', this._query, { b: this._frames });
+  return error.message.replace(' in:\n', '');
+}
+
+module.exports = getQueryString;

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,10 @@ const inspect = (r: RethinkDBDashInstance, callbacks: Callbacks) => {
     // Call the original .run
     return run.call(this, ...args).then(arg => {
       if (onQueryComplete) {
-        onQueryComplete(getQuery.call(this), now() - start);
+        onQueryComplete(
+          getQuery.call(this),
+          Number((now() - start).toFixed(2))
+        );
       }
       return arg;
     });

--- a/src/test/__snapshots__/index.test.js.snap
+++ b/src/test/__snapshots__/index.test.js.snap
@@ -4,3 +4,8 @@ exports[`inspect should call the onQuery callback when a query is run 1`] = `
 "r.db(\\"test\\").table(\\"bla\\").get(\\"asdf123\\")
 "
 `;
+
+exports[`inspect should call the onQueryComplete callback with timing information 1`] = `
+"r.db(\\"test\\").table(\\"bla\\").get(\\"asdf123\\")
+"
+`;

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -11,17 +11,17 @@ describe('inspect', () => {
     expect(r._Term.prototype.run.name).toEqual('inspectRun');
   });
 
-  it('should call the onQuery callback when a query is run', () => {
+  it('should call the onQuery callback when a query is run', async () => {
     const r = rethinkdbdash({
       pool: false,
     });
-    const run = jest.fn();
+    const run = jest.fn(() => Promise.resolve('a'));
     r._Term.prototype.run = run;
     const onQuery = jest.fn();
     inspect(r, {
       onQuery,
     });
-    r
+    await r
       .db('test')
       .table('bla')
       .get('asdf123')
@@ -29,5 +29,26 @@ describe('inspect', () => {
     expect(run).toHaveBeenCalledTimes(1);
     expect(onQuery).toHaveBeenCalledTimes(1);
     expect(onQuery.mock.calls[0][0]).toMatchSnapshot();
+  });
+
+  it('should call the onQueryComplete callback with timing information', async () => {
+    const r = rethinkdbdash({
+      pool: false,
+    });
+    const run = jest.fn(() => Promise.resolve('a'));
+    r._Term.prototype.run = run;
+    const onQueryComplete = jest.fn();
+    inspect(r, {
+      onQueryComplete,
+    });
+    await r
+      .db('test')
+      .table('bla')
+      .get('asdf123')
+      .run();
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(onQueryComplete).toHaveBeenCalledTimes(1);
+    expect(onQueryComplete.mock.calls[0][0]).toMatchSnapshot();
+    expect(onQueryComplete.mock.calls[0][1]).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
```JS
inspect(r, {
  onQueryComplete: (query, time) => {
    console.log(query, time);
  }
})
```

This callback gets the same string of the query that `onQuery` gets, but also gets the time it took for the query to complete. This can be useful for performance optimizations.